### PR TITLE
WIP : Mechanism to get logs from the workloads

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -13,6 +13,10 @@ spec:
         name: benchmark-operator
     spec:
       serviceAccountName: benchmark-operator
+      volumes:
+      - name: bench-results
+        persistentVolumeClaim:
+          claimName: bench-results
       containers:
         - name: benchmark-operator
           # Replace this with the built image name
@@ -29,3 +33,6 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "benchmark-operator"
+          volumeMounts:
+            - mountPath: "/tmp/results"
+              name: bench-results

--- a/deploy/result-pvc.yaml
+++ b/deploy/result-pvc.yaml
@@ -1,0 +1,12 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: bench-results
+spec:
+    accessModes:
+      - ReadWriteMany
+    storageClassName: standard
+    resources:
+        requests:
+            storage: 1Gi

--- a/roles/fio-bench/tasks/main.yml
+++ b/roles/fio-bench/tasks/main.yml
@@ -28,14 +28,26 @@
           command: ["/bin/sh","-c"]
           args:
            - "cat /tmp/fio/fiojob;
-              fio /tmp/fio/fiojob"
+              fio /tmp/fio/fiojob | tee /tmp/results/fio-result"
           volumeMounts:
+          - name: result-volume
+            mountPath: "/tmp/results"
           - name: config-volume
             mountPath: "/tmp/fio"
         volumes:
+        - name: result-volume
+          persistentVolumeClaim:
+            claimName: bench-results
         - name: config-volume
           configMap:
             name: fio-test
         restartPolicy: Never
   when: fio.clients > 0
   with_sequence: start=1 count={{fio.clients}}
+
+- name: Get Results
+  command: 'cat /tmp/results/fio-result'
+  register: results
+
+- debug:
+    msg: "Results : {{ results }}"

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -13,6 +13,7 @@ function operator_requirements {
   kubectl apply -f deploy/role_binding.yaml
   kubectl apply -f deploy/service_account.yaml
   kubectl apply -f deploy/crds/bench_v1alpha1_bench_crd.yaml
+  kubectl apply -f deploy/result-pvc.yaml
 }
 
 function create_operator {


### PR DESCRIPTION
There is a commit for k8s_log which would allow us to capture the logs
of the workloads. This solution makes use of a pvc which can be written
and read from multiple locations. The Benchmark Operator will also read
from this volume, allowing us to display the results from the operator.