### PR TITLE
Sysbench template workload

### DIFF
--- a/deploy/cluster_role_kubevirt.yaml
+++ b/deploy/cluster_role_kubevirt.yaml
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: benchmark-operator-kube
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+    - subresources.kubevirt.io
+  resources:
+    - virtualmachineinstances/console
+    - virtualmachineinstances/vnc
+  verbs:
+    - get
+- apiGroups:
+    - kubevirt.io
+  resources:
+    - virtualmachineinstances
+    - virtualmachines
+    - virtualmachineinstancepresets
+    - virtualmachineinstancereplicasets
+  verbs:
+    - get
+    - delete
+    - create
+    - update
+    - patch
+    - list
+    - watch
+    - deletecollection
+- apiGroups: [""]
+  resources:
+    - configmaps
+  resourceNames:
+    - kubevirt-config
+  verbs:
+    - update
+    - get
+    - patch

--- a/resources/crds/bench_v1alpha1_bench_cr.yaml
+++ b/resources/crds/bench_v1alpha1_bench_cr.yaml
@@ -23,6 +23,8 @@ spec:
     filesize: 1
   sysbench:
     enabled: false
+    #kind: vm
+    # If you want to run this as a VM uncomment the above
     tests:
     - name: cpu
       parameters:
@@ -30,7 +32,7 @@ spec:
     - name: fileio
       parameters:
         file-test-mode: rndrw
-  couchbase: 
+  couchbase:
     # To disable couchbase, set servers.size to 0
     # Typical deployment size is 3
     servers:

--- a/roles/sysbench/defaults/main.yml
+++ b/roles/sysbench/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 sysbench:
+  kind: job
   enabled: true
   tests:
   - name: cpu

--- a/roles/sysbench/tasks/main.yml
+++ b/roles/sysbench/tasks/main.yml
@@ -11,32 +11,14 @@
       data:
         sysbenchScript: "{{ lookup('template', 'sysbench.sh.j2') }}"
 
-- name: start sysbench job
+- name: Start sysbench job
   k8s:
-    definition:
-      kind: Job
-      apiVersion: batch/v1
-      metadata:
-        name: '{{ meta.name }}-sysbench'
-        namespace: '{{ meta.namespace }}'
-      spec:
-        ttlSecondsAfterFinished: 600
-        template:
-          metadata:
-            labels:
-              app: sysbench
-          spec:
-            containers:
-            - name: sysbench
-              command: ["/bin/sh", "-c"]
-              args: ["/tmp/sysbenchScript"]
-              image: "docker.io/smalleni/centos-sysbench:latest"
-              volumeMounts:
-              - name: sysbench-volume
-                mountPath: "/tmp/"
-            volumes:
-            - name: sysbench-volume
-              configMap:
-                name: '{{ meta.name }}-sysbench-config'
-                defaultMode: 0777
-            restartPolicy: OnFailure
+    state: present
+    definition: "{{ lookup('template', 'workload.yml') | from_yaml }}"
+  when: sysbench.kind is not defined
+
+- name: Start sysbench vm job
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'workload_vm.yml') | from_yaml }}"
+  when:  sysbench.kind is defined and sysbench.kind == "vm"

--- a/roles/sysbench/templates/workload.yml
+++ b/roles/sysbench/templates/workload.yml
@@ -1,0 +1,28 @@
+---
+
+apiVersion: batch/v1
+kind: "job"
+metadata:
+  name: "{{ meta.name }}-sysbench"
+  namespace: "{{ meta.namespace }}"
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+       app: sysbench
+    spec:
+      containers:
+      - name: sysbench
+        command: ["/bin/sh", "-c"]
+        args: ["/tmp/sysbenchScript"]
+        image: "docker.io/smalleni/centos-sysbench:latest"
+        volumeMounts:
+        - name: sysbench-volume
+          mountPath: "/tmp/"
+      volumes:
+      - name: sysbench-volume
+        configMap:
+          name: "{{ meta.name }}-sysbench-config"
+          defaultMode: 0777
+      restartPolicy: OnFailure

--- a/roles/sysbench/templates/workload_vm.yml
+++ b/roles/sysbench/templates/workload_vm.yml
@@ -1,0 +1,34 @@
+---
+
+apiVersion: kubevirt.io/v1alpha3
+kind: "VirtualMachineInstance"
+metadata:
+  name: "{{ meta.name }}-sysbench"
+  namespace: "{{ meta.namespace }}"
+  labels:
+    kubevirt-vm: vm-sysbench
+spec:
+  domain:
+    devices:
+      disks:
+      - disk:
+          bus: virtio
+        name: containerdisk
+      - disk:
+          bus: virtio
+        name: workload
+    machine:
+      type: ""
+    resources:
+      requests:
+        memory: "1024M"
+  terminationGracePeriodSeconds: 0
+  volumes:
+  - containerDisk:
+      image: "{{ sysbench.image }}"
+    name: containerdisk
+  - cloudInitNoCloud:
+      userData: |
+        #!/bin/sh
+        echo 'workload'
+    name: workload


### PR DESCRIPTION
Instead of defining the job/pod/etc in the task we should create a
template which can easily be modified to support different scenarios.

partially fixes #35